### PR TITLE
datasets to data sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,14 +11,13 @@ You’re going to program a [legal data scraper](https://docs.pdap.io/meta/legal
 ### Best Practices
 - We can run the scraper by running one script, called `scraper.py` or at least beginning `scraper-`
 - Populate the readme for your scraper with as much helpful information as you can!
-- The config file appropriately references a dataset.
+- The config file appropriately references a Data Source.
 - Include a truncated version of some sample data so we understand what is generated.
-- Ensure you have a `schema.json` file & a blank `etl.py` file in your scraper directory, and call `import etl` at the end of your scraper. [Read more about Scraper Schemas here](https://docs.pdap.io/components/datasets/scraper_schemas).
 - Stick to the format of `USA/$STATE/$COUNTY/$RECORD_TYPE`.
 
-## 1. Find a dataset to scrape.
+## 1. Find a Data Source to scrape.
 
-Navigate to our [Datasets repo in DoltHub](https://www.dolthub.com/repositories/pdap/datasets) or the [PostgreSQL mirror](https://docs.pdap.io/components/datasets/hadoop-datasets-mirror) and find a source to scrape. If you have a particular dataset in mind you may need to [add it dataset yourself](https://docs.pdap.io/components/data-collection/dataset-catalog/submit-or-update-datasets). This takes about 5–10 minutes. 
+Navigate to our [Data Sources repo in DoltHub](https://www.dolthub.com/repositories/pdap/data_sources) or the [PostgreSQL mirror](https://docs.pdap.io/activities/data-storage/submit-or-update-datasets/hadoop-datasets-mirror) and find a source to scrape. If you have a particular data source in mind you may need to [add it yourself](https://docs.pdap.io/activities/data-storage/submit-or-update-datasets). This takes about 5–10 minutes. 
 
 
 ## 2. Get set up locally.
@@ -31,11 +30,11 @@ Navigate to our [Datasets repo in DoltHub](https://www.dolthub.com/repositories/
    - [@Pythonidaer](https://github.com/Pythonidaer/pythonidaer) made an [excellent walkthrough of the GUI as of the v0.0.1 release](https://www.youtube.com/watch?v=oJxXkSytreE).
 4. Copy the resulting folder into your clone of `PDAP-Scrapers`.
 
-## 3. Check the `/common` `/Base_Scripts` folder for helpful assets and scrapers before you start. 
+## 3. Check the `/common` `/Base_Scripts` folder for helpful assets and scrapers before you start.
 [`/common` folder here!](https://github.com/Police-Data-Accessibility-Project/PDAP-Scrapers/tree/main/common/)
 [`/Base_Scripts` folder here!](https://github.com/Police-Data-Accessibility-Project/PDAP-Scrapers/tree/main/Base_Scripts/Scrapers)
 
-Why start from scratch if we have a useful library? Keep in mind that we can always refactor your work later if necessary, so if you're not sure, we still want 
+Why start from scratch if we have a useful library? Keep in mind that we can always refactor your work later if necessary, so if you're not sure, we still want
 you to submit!
 
 ## 4. Code your scraper and make a Pull Request!
@@ -46,7 +45,7 @@ Make sure you follow this guideline for creating folders:
 ```
 COUNTRY/
   STATE/
-    COUNTY/ 
+    COUNTY/
       DEPARTMENT_TYPE
                 (CITY)
                 (COUNTY)
@@ -70,4 +69,3 @@ Python is preferred. If you use another language, we may not be able to easily f
 > Are there any specific formatting guidelines I should adhere to?
 
 For now, if you use Python: Try to stick with PEP8 formatting. A good formatter for this is [Black](https://github.com/psf/black).
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To write a scraper, start with [CONTRIBUTING.md](https://github.com/Police-Data-
 For everything else, start with [docs.pdap.io](https://docs.pdap.io/).
 
 ## What data are we scraping?
-The [datasets listed here](https://www.dolthub.com/repositories/pdap/datasets/query/master?q=SELECT+*%0AFROM+%60datasets%60%0Awhere+status_id+%3D+1%0A%0A&active=Tables) are our to-do list. If we should targeting a new data type, suggest it in Discord or make a DoltHub PR!
+The [data sources listed here](https://www.dolthub.com/repositories/pdap/datasets/query/master?q=SELECT+*%0AFROM+%60datasets%60%0Awhere+status_id+%3D+1%0A%0A&active=Tables) are our to-do list. If we should targeting a new data type, suggest it in Discord or make a DoltHub PR!
 
 ## Resources
 Potentially useful tools. If you find something useful, or if one of these is out of date, make a PR!

--- a/common/etl/pdap_dolt.py
+++ b/common/etl/pdap_dolt.py
@@ -2,6 +2,8 @@
 PDAP - Dolt
 
 Library for re-usable functions pertaining to our dolt instance
+
+NOTE: This is near-deprecated and likely broken by changing "datasets" to "data sources" in dolt and via commit 8a672ffb7cc05a474dfbb02243dfba656dc4a5cf.
 '''
 
 from doltpy.cli import Dolt

--- a/common/etl/pdap_dolt.py
+++ b/common/etl/pdap_dolt.py
@@ -23,9 +23,9 @@ dev_mode = False
 
 dolthub_org = 'pdap'
 
-dolthub_repo = 'datasets'
+dolthub_repo = 'data_sources'
 dolthub_fullrepo = dolthub_org + '/' + dolthub_repo
-dolthub_table = 'datasets'
+dolthub_table = 'data_sources'
 dolthub_branch = 'master'
 
 intake_repo = 'data-intake'
@@ -33,7 +33,7 @@ intake_fullrepo = dolthub_org + '/' + intake_repo
 intake_table = 'incident_reports'
 intake_branch = 'master'
 
-dolt = None # dolt datasets repo
+dolt = None # dolt data_sources repo
 intake = None # dolt intake repo
 
 
@@ -66,74 +66,74 @@ def init(branch=dolthub_branch, intake_branch=intake_branch):
         Dolt.pull(intake)
         s = Dolt.status(dolt)
         s2 = Dolt.status(intake)
-        
-        print('   [*] Current Status: datasets: {} / intake: {}'.format(s, intake))
+
+        print('   [*] Current Status: data_sources: {} / intake: {}'.format(s, intake))
     else:
         # clone the database from DoltHub, save it into a var to be referenced for read/write purposes
-        print(' [*] Cloning Datasets Repo: {} into ./{}'.format(dolthub_fullrepo, dolthub_repo))
+        print(' [*] Cloning Data Sources Repo: {} into ./{}'.format(dolthub_fullrepo, dolthub_repo))
         dolt = Dolt.clone(dolthub_fullrepo, branch=branch)
         print(' [*] Cloning Intake Repo: {} into ./{}'.format(intake_fullrepo, intake_repo))
         intake = Dolt.clone(intake_fullrepo, branch=intake_branch)
-        print('   [*] Current Branch: datasets: {} / intake:'.format(Dolt.branch(dolt)[0].name,Dolt.branch(intake)[0].name))
+        print('   [*] Current Branch: data_sources: {} / intake:'.format(Dolt.branch(dolt)[0].name,Dolt.branch(intake)[0].name))
     return dolt, intake
 
 '''
-    Search the [pdap/datasets].[datasets] database for the specified URL
+    Search the [pdap/data_sources].[data_sources] database for the specified URL
     If it does not exist, pass agency info to new func to create it
 '''
-def get_dataset(dolt, dataset_url, agency):
-    # data = read_pandas_sql(dolt, "SELECT * FROM datasets WHERE url = 'https://cityprotect.com/agency/540048e6-ee66-4a6f-88ae-0ceb93717e50'")
-    data = read_pandas_sql(dolt, "SELECT * FROM datasets WHERE url = '{}'".format(dataset_url))
+def get_data_source(dolt, data_source_url, agency):
+    # data = read_pandas_sql(dolt, "SELECT * FROM data_sources WHERE url = 'https://cityprotect.com/agency/540048e6-ee66-4a6f-88ae-0ceb93717e50'")
+    data = read_pandas_sql(dolt, "SELECT * FROM data_sources WHERE url = '{}'".format(data_source_url))
     # check if a result was passed
     if data.shape[0] == 0:
-        print(" [X] No Dataset Found! Proceeding to Add New Dataset...")
-        return new_dataset(dolt, agency, dataset_url)
-    if data.shape[0] == 1: 
-        print(" [!] Found Existing Dataset Record: ID #{}!".format(data.loc[0, 'id']))
+        print(" [X] No Data Source Found! Proceeding to Add New Data Source...")
+        return new_data_source(dolt, agency, data_source_url)
+    if data.shape[0] == 1:
+        print(" [!] Found Existing Data Source Record: ID #{}!".format(data.loc[0, 'id']))
         return data
 
 '''
-    Search the [pdap/datasets].[datasets] database for the specified URL
+    Search the [pdap/data_sources].[data_sources] database for the specified URL
     If it does not exist, pass agency info to new func to create it
 
     This method will verify the data from dolt exactly matches the data in the schema.json
 '''
-def get_dataset_from_schema(dolt, schema_dataset, agency, full_schema, idx):
+def get_data_source_from_schema(dolt, schema_data_source, agency, full_schema, idx):
     # method 1: check if id is set first
-    if schema_dataset['dataset_id']:
-        dolt_data = read_pandas_sql(dolt, "SELECT * FROM datasets WHERE id = '{}'".format(schema_dataset['dataset_id']))
+    if schema_data_source['data_source_id']:
+        dolt_data = read_pandas_sql(dolt, "SELECT * FROM data_sources WHERE id = '{}'".format(schema_data_source['data_source_id']))
     # else grab the url and check via that
     else:
-        dolt_data = read_pandas_sql(dolt, "SELECT * FROM datasets WHERE url = '{}'".format(schema_dataset['url']))
+        dolt_data = read_pandas_sql(dolt, "SELECT * FROM data_sources WHERE url = '{}'".format(schema_data_source['url']))
     # check if a result was passed
 
     # if not, make one
     if dolt_data.shape[0] == 0:
-        print(" [X] No Dataset Found! Proceeding to Add New Dataset...")
-        return new_dataset_from_schema(dolt, agency, schema_dataset, full_schema, idx)
+        print(" [X] No Data Source Found! Proceeding to Add New Data Source...")
+        return new_data_source_from_schema(dolt, agency, schema_data_source, full_schema, idx)
     # if so, compare the db data to the schema.json and consolidate
-    if dolt_data.shape[0] == 1: 
-        print(" [!] Found Existing Dataset Record: ID #{}!".format(dolt_data.loc[0, 'id']))
+    if dolt_data.shape[0] == 1:
+        print(" [!] Found Existing Data Source Record: ID #{}!".format(dolt_data.loc[0, 'id']))
         # compare the changes from the db to the schema.json to consolidate before returning
-        return merge_dataset_info(full_schema, dolt_data, idx)
+        return merge_data_source_info(full_schema, dolt_data, idx)
 
 
 ''' merge the data from the db back into the schema '''
-def merge_dataset_info(schema, dataset, index):
-    # compare the last_modified time of the json vs the 
+def merge_data_source_info(schema, data_source, index):
+    # compare the last_modified time of the json vs the
 
     # merge the data back into the schema
-    schema['data'][index]['dataset_id']     = dataset.loc[0, 'id']
-    schema['data'][index]['source_type']    = dataset.loc[0, 'source_type_id']
-    schema['data'][index]['data_type']      = dataset.loc[0, 'data_type_id']
-    schema['data'][index]['format_type']    = dataset.loc[0, 'format_type_id']
-    schema['data'][index]['update_freq']    = dataset.loc[0, 'update_frequency']
+    schema['data'][index]['data_source_id']     = data_source.loc[0, 'id']
+    schema['data'][index]['source_type']    = data_source.loc[0, 'source_type_id']
+    schema['data'][index]['data_type']      = data_source.loc[0, 'data_type_id']
+    schema['data'][index]['format_type']    = data_source.loc[0, 'format_type_id']
+    schema['data'][index]['update_freq']    = data_source.loc[0, 'update_frequency']
 
-    return schema, dataset
+    return schema, data_source
 
-''' 
+'''
     used if agency_id is filled out in the schema
-    RETURN: the uuid of the dataset or ''
+    RETURN: the uuid of the data_source or ''
 '''
 def get_agency_by_uuid(dolt, uuid):
     try:
@@ -142,7 +142,7 @@ def get_agency_by_uuid(dolt, uuid):
         if data.shape[0] == 0:
             print("       [X] No Agency Found!")
             return ''
-        if data.shape[0] == 1: 
+        if data.shape[0] == 1:
             print("       [!] Found Agency ID #{}!".format(data.loc[0, 'id']))
             return data.loc[0, 'id']
     except:
@@ -157,7 +157,7 @@ def get_agency_id(dolt, name, state):
         if data.shape[0] == 0:
             print("       [X] No Agency Found!")
             return ''
-        if data.shape[0] == 1: 
+        if data.shape[0] == 1:
             print("       [!] Found Agency ID #{}!".format(data.loc[0, 'id']))
             return data.loc[0, 'id']
     except:
@@ -190,14 +190,14 @@ def new_branch(dolt, intake):
 This was legacy used for cityprotect data and will most likely be deprecated
 
 '''
-def new_dataset(dolt, agency, url):
-    print('   [*] Adding a New Dataset:')
+def new_data_source(dolt, agency, url):
+    print('   [*] Adding a New Data Source:')
     name = agency['name'].replace("'", '')
     print('     [*] name: {}'.format(name))
     print('     [*] url: {}'.format(url))
     status_id = 5
     print('     [*] status: {}'.format('5 - Initial Data Loaded'))
-    
+
     source_type_id = 3 # Third Party
     print('     [*] source type: {}'.format('Third Party'))
     data_types_id = 10 # Incident Reports
@@ -215,7 +215,7 @@ def new_dataset(dolt, agency, url):
     response = requests.get(fcc)
     # print(response.text)
     json_resp = json.loads(response.text)
-    
+
 
     fips = json_resp['results'][0]['county_fips']
     print("     [*] fips: {}".format(fips))
@@ -247,20 +247,20 @@ def new_dataset(dolt, agency, url):
         'scraper_id': scraper_id,
         'notes': notes
     }])
-    print("   [*] Inserting data to datasets table...")
+    print("   [*] Inserting data to Data Sources table...")
 
     id = str(uuid.uuid4()).replace('-','') # UUID without dashes
-    insert = dolt.sql("INSERT into datasets ('id', 'url', 'status_id', 'name', 'source_type_id', 'data_types_id', 'format_types_id', 'agency_id', 'update_frequency', 'portal_type', 'coverage_start', 'scraper_id', 'notes') VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}');".format(id, url, status_id, name, source_type_id, data_types_id, format_types_id,  agency_id, update_freq, portal, start, scraper_id, notes), result_format="csv")
+    insert = dolt.sql("INSERT into data_sources ('id', 'url', 'status_id', 'name', 'source_type_id', 'data_types_id', 'format_types_id', 'agency_id', 'update_frequency', 'portal_type', 'coverage_start', 'scraper_id', 'notes') VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}');".format(id, url, status_id, name, source_type_id, data_types_id, format_types_id,  agency_id, update_freq, portal, start, scraper_id, notes), result_format="csv")
 
     # and grab the record
-    data = read_pandas_sql(dolt, "select * from datasets where id = '{}'".format(id))
-    print(" [!] Inserted Dataset Record: ID #{}!".format(data.loc[0, 'id']))
+    data = read_pandas_sql(dolt, "select * from data_sources where id = '{}'".format(id))
+    print(" [!] Inserted Data Source Record: ID #{}!".format(data.loc[0, 'id']))
     return data
 
 ''' load the data from the schema '''
-def new_dataset_from_schema(dolt, agency, schema_dataset, full_schema, idx):
-    print('   [*] Adding a New Dataset:')
-    url = schema_dataset['url']
+def new_data_source_from_schema(dolt, agency, schema_data_source, full_schema, idx):
+    print('   [*] Adding a New Data Source:')
+    url = schema_data_source['url']
     print('     [*] url: {}'.format(url))
     status_id = 5
     print('     [*] status: {}'.format('5 - Initial Data Loaded'))
@@ -268,12 +268,12 @@ def new_dataset_from_schema(dolt, agency, schema_dataset, full_schema, idx):
     # agencies method: get_agency_by_uuid
     agency_id = agency
     print('     [*] agency_id: {}'.format(agency_id))
-    
-    source_type_id = schema_dataset['source_type'] # Third Party
+
+    source_type_id = schema_data_source['source_type'] # Third Party
     print('     [*] source type: {}'.format(source_type_id))
-    data_types_id = schema_dataset['data_type'] # Incident Reports
+    data_types_id = schema_data_source['data_type'] # Incident Reports
     print('     [*] data type: {}'.format(data_types_id))
-    format_types_id = schema_dataset['format_type'] # CityProtect
+    format_types_id = schema_data_source['format_type'] # CityProtect
     print('     [*] format type: {}'.format(format_types_id))
 
 
@@ -283,12 +283,12 @@ def new_dataset_from_schema(dolt, agency, schema_dataset, full_schema, idx):
     response = requests.get(fcc)
     # print(response.text)
     json_resp = json.loads(response.text)
-    
+
 
     fips = json_resp['results'][0]['county_fips']
     print("     [*] fips: {}".format(fips))
     '''
-    update_freq = schema_dataset['update_freq'] # quarterly
+    update_freq = schema_data_source['update_freq'] # quarterly
     print('     [*] update freq: {}'.format(update_freq))
 
 
@@ -309,18 +309,18 @@ def new_dataset_from_schema(dolt, agency, schema_dataset, full_schema, idx):
         'scraper_id': scraper_id,
         'notes': notes
     }])
-    print("   [*] Inserting data to datasets table...")
+    print("   [*] Inserting data to Data Sources table...")
 
     id = str(uuid.uuid4()).replace('-','') # UUID without dashes
-    insert = dolt.sql("INSERT INTO datasets (id, url, status_id, source_type_id, data_types_id, format_types_id, agency_id, update_frequency, scraper_id, notes) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}');".format(id, url, status_id, source_type_id, data_types_id, format_types_id,  agency_id, update_freq, scraper_id, notes), result_format="csv")
+    insert = dolt.sql("INSERT INTO data_sources (id, url, status_id, source_type_id, data_types_id, format_types_id, agency_id, update_frequency, scraper_id, notes) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}');".format(id, url, status_id, source_type_id, data_types_id, format_types_id,  agency_id, update_freq, scraper_id, notes), result_format="csv")
 
     # and grab the record
-    data = read_pandas_sql(dolt, "select * from datasets where id = '{}'".format(id))
-    print(" [!] Inserted Dataset Record: ID #{}!".format(data.loc[0, 'id']))
+    data = read_pandas_sql(dolt, "select * from data_sources where id = '{}'".format(id))
+    print(" [!] Inserted Data Source Record: ID #{}!".format(data.loc[0, 'id']))
     # update the schema file with the lastest info
     # since everything was used from the file to create, only the id and last_modified
     # will change
-    full_schema['data'][idx]['dataset_id'] = data.loc[0, 'id']
+    full_schema['data'][idx]['data_source_id'] = data.loc[0, 'id']
     full_schema['data'][idx]['last_modified'] = data.loc[0, 'last_modified']
 
     # return back
@@ -328,16 +328,16 @@ def new_dataset_from_schema(dolt, agency, schema_dataset, full_schema, idx):
 
 
 '''
-We use our dolt object, the dataset record passsed from either get_dataset() or new_dataset()
-and the file. 
+We use our dolt object, the Data Source record passsed from either get_data_source() or new_data_source()
+and the file.
 
-Due to limitations in dolt, we will have to load each line of the csv, add our dataset_id,
+Due to limitations in dolt, we will have to load each line of the csv, add our data_source_id,
 and then run a dolt.sql('INSERT ...') statement for each row so auto_inc works.
 
 Alternatively, remove auto_inc and use guids so we can create them here, then we could
 use their load_pandas methods or such
 '''
-def load_data(intake, dataset_record, file):
+def load_data(intake, data_source_record, file):
     print('  [*] Enumerating records from {} for import'.format(file.name))
 
     # load the file into a dataframe
@@ -347,12 +347,12 @@ def load_data(intake, dataset_record, file):
     df = pd.concat([pd.Series([str(uuid.uuid4()).replace('-','') for _ in range(len(df.index))], index=df.index, name='id'), df], axis=1)
     # set the index to our new ID column
     df.set_index('id')
-    # add the datasets_fk
-    df['datasets_id']=dataset_record.loc[0, 'id']
+    # add the data_sources_fk
+    df['data_sources_id']=data_source_record.loc[0, 'id']
     # format the date columns
     df['date'] = pd.to_datetime(df['date'], errors='coerce', format='%m/%d/%Y, %I:%M:%S %p')
     df['updateDate'] = pd.to_datetime(df['updateDate'], errors='coerce', format='%m/%d/%Y, %I:%M:%S %p')
-    
+
     '''
     This currently does not work. It is supposed to be doltpy's method of taking a dataframe and enumerating itself
 
@@ -361,7 +361,7 @@ def load_data(intake, dataset_record, file):
     # on windows the path to the repo is C:\\Users\\you\\wherever\\this\\file\\is
     # it causes sql alchemy to freak
     # by creating a new dolt instance and stating the repo is just here in this dir, it allows it to work
-    db = Dolt(repo_dir = 'datasets', print_output = False)
+    db = Dolt(repo_dir = 'data_sources', print_output = False)
     # set our server config
     sc = ServerConfig(branch=Dolt.branch(dolt)[0].name, user='root')
     # create a sql server process
@@ -382,7 +382,7 @@ def load_data(intake, dataset_record, file):
             print('    [-] Importing record: {} - ccn:'.format(row['id'], row['ccn']))
             # sometimes may get a glitch like an invalid date
             try:
-                insert = intake.sql("INSERT into incident_reports ('id', 'ccn', 'incidentDate', 'updateDate', 'city', 'state', 'postalCode', 'blocksizedAddress', 'incidentType', 'parentIncidentType', 'narrative', 'datasets_id') VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}');".format(row['id'], row['ccn'], row['date'], row['updateDate'], row['city'], row['state'], row['postalCode'], row['blocksizedAddress'], row['incidentType'], row['parentIncidentType'], row['narrative'], row['datasets_id']))
+                insert = intake.sql("INSERT into incident_reports ('id', 'ccn', 'incidentDate', 'updateDate', 'city', 'state', 'postalCode', 'blocksizedAddress', 'incidentType', 'parentIncidentType', 'narrative', 'data_sources_id') VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}');".format(row['id'], row['ccn'], row['date'], row['updateDate'], row['city'], row['state'], row['postalCode'], row['blocksizedAddress'], row['incidentType'], row['parentIncidentType'], row['narrative'], row['data_sources_id']))
             except:
                 print('      [!] Error importing record: {} - ccn:'.format(row['id'], row['ccn']))
         print('    [*] Done!')
@@ -390,21 +390,21 @@ def load_data(intake, dataset_record, file):
         print('    [!] Error Iterating over rows! Skipping file {}'.format(file.name))
 
 '''
-    This function will ensure ALL of the columns in the DB are represented, 
-    so if new columns are added to the schema, this function will also load them 
+    This function will ensure ALL of the columns in the DB are represented,
+    so if new columns are added to the schema, this function will also load them
     back to the schema as "__unmapped__" in case the data source does have a column
     that could map to it
 
     Args:
-    dolt - the dolt [pdap/datasets] instance
+    dolt - the dolt [pdap/data_sources] instance
     intake - the dolt [pdap/data-intake] instance
     schema - the full schema.json file loaded in memory
-    dataset_record - a Pandas DataFrame of the particular record in [pdap/datasets].datasets
+    data_source_record - a Pandas DataFrame of the particular record in [pdap/data_sources].data_sources
     idx - the current index of the schema['data'] that we are on
 '''
-def merge_dataset_mapping(dolt, intake, schema, dataset_record, idx):
-    
-    data = read_pandas_sql(dolt, "SELECT * FROM data_types where id =  '{}'".format(dataset_record.loc[0, 'data_types_id']))
+def merge_data_source_mapping(dolt, intake, schema, data_source_record, idx):
+
+    data = read_pandas_sql(dolt, "SELECT * FROM data_types where id =  '{}'".format(data_source_record.loc[0, 'data_types_id']))
     # if a result does not exist then fail the script, we must have a proper data_type
     # and at this point we cannot accurately derive one
     if data.shape[0] == 0:
@@ -412,7 +412,7 @@ def merge_dataset_mapping(dolt, intake, schema, dataset_record, idx):
         sys.exit() # exit the script
 
     # we have a result, let's do stuff with it
-    if data.shape[0] == 1: 
+    if data.shape[0] == 1:
         intake_table_name = data.loc[0, 'name']
         print('    [*] Fetching columns for {} data type'.format(intake_table_name))
         cols = read_pandas_sql(intake, "DESCRIBE {}".format(intake_table_name))
@@ -434,22 +434,22 @@ def merge_dataset_mapping(dolt, intake, schema, dataset_record, idx):
 
                 # with the above data, we need to compare it to the mapping
 
-                # this is the actual column in the "mapping" object of our current dataset in the schema.json
+                # this is the actual column in the "mapping" object of our current data_source in the schema.json
                 # we will need to test to see if it exists first
                 if field_name in schema['data'][idx]['mapping']:
-                    print('      [*] Found column {} for dataset in schema.json'.format(field_name))
+                    print('      [*] Found column {} for Data Source in schema.json'.format(field_name))
                 else:
-                    print('      [x] Missing column {} for dataset in schema.json, adding...'.format(field_name))
+                    print('      [x] Missing column {} for Data Source in schema.json, adding...'.format(field_name))
                     # figure out what to set the missing column to
                     if field_name in ['id']:
                         schema['data'][idx]['mapping'][field_name] = "__uuid__"
                     elif field_name in ['date_insert', 'date_update']:
                         schema['data'][idx]['mapping'][field_name] = "__date__"
-                    elif field_name == 'datasets_id':
-                        schema['data'][idx]['mapping'][field_name] = "__dataset_id__"
+                    elif field_name == data_sources_id':
+                        schema['data'][idx]['mapping'][field_name] = "__data_source_id__"
                     else:
                         schema['data'][idx]['mapping'][field_name] = "__skip__"
-    
+
     # grab our freshly merged mapping
     intake_db_cols = schema['data'][idx]['mapping']
     # return the full schema back out with the intake cols and table name
@@ -461,13 +461,13 @@ def merge_dataset_mapping(dolt, intake, schema, dataset_record, idx):
 
     Args:
     intake - the dolt [pdap/data-intake] instance
-    intake_db_cols - a JSON object - columns from merge_dataset_mapping so we know how to map
+    intake_db_cols - a JSON object - columns from merge_data_source_mapping so we know how to map
     intake_table_name - name of the table the data will be loaded into
-    dataset_record - a Pandas DataFrame of the particular record in [pdap/datasets].datasets
+    data_source_record - a Pandas DataFrame of the particular record in [pdap/data_sources].data_sources
     file - the csv file path
 '''
-def load_csv_data_from_schema_map(intake, intake_db_cols, intake_table_name, dataset_record, file):
-    
+def load_csv_data_from_schema_map(intake, intake_db_cols, intake_table_name, data_source_record, file):
+
     print('  [*] Enumerating records from {} for import'.format(file.name))
 
     # load the file into a dataframe
@@ -476,7 +476,7 @@ def load_csv_data_from_schema_map(intake, intake_db_cols, intake_table_name, dat
 
     # dynamically build the insert statement
     # https://stackoverflow.com/questions/51975479/parsing-json-into-insert-statements-with-python
-    
+
 
     try:
         # first loop through each record in the flatfile
@@ -485,7 +485,7 @@ def load_csv_data_from_schema_map(intake, intake_db_cols, intake_table_name, dat
             keylist = "("
             valuelist = "("
             firstPair = True # first index no , before it
-            # key - Dolt db column name 
+            # key - Dolt db column name
             # value - scraped file column name / dataframe col name
             for key, value in intake_db_cols.items():
                 if not firstPair:
@@ -493,16 +493,16 @@ def load_csv_data_from_schema_map(intake, intake_db_cols, intake_table_name, dat
                     valuelist += ", "
                 firstPair = False
                 keylist += key
-                
+
                 # generate any UUIDs
                 if value == '__uuid__':
                     valuelist +=  "'" + str(uuid.uuid4()).replace('-','') + "'"
                 # generate any dates
                 elif value == '__date__':
                     valuelist +=  "CAST('"+ str(datetime.datetime.now()) + "' as datetime)"
-                # fill in the dataset id
-                elif value == '__dataset_id__':
-                    valuelist +=  "'" + str(dataset_record.loc[0, 'id']) + "'"
+                # fill in the data_source id
+                elif value == '__data_source_id__':
+                    valuelist +=  "'" + str(data_source_record.loc[0, 'id']) + "'"
                 # NULL out any skips
                 elif value == '__skip__':
                     valuelist += 'NULL'
@@ -531,14 +531,14 @@ def load_csv_data_from_schema_map(intake, intake_db_cols, intake_table_name, dat
         print('    [!] Error Iterating over rows! Skipping file {}. Error: {}'.format(file.name, traceback.print_exc()))
 
     # first loop through the mapping to grab the dolt col (key) and the flat file key (value)
-    
+
 
 
     #instead, we will just loop our data
-    
 
 
-    
+
+
 ''' push the changes to our custom branch '''
 def commit(dolt, intake):
     branch = Dolt.branch(dolt)[0].name

--- a/setup_gui/schema_template.json
+++ b/setup_gui/schema_template.json
@@ -11,7 +11,7 @@
       },
       "data": [
           {
-              "dataset_id": "",
+              "data_source__id": "",
               "url":"",
               "full_data_location":"data",
               "source_type": 2,


### PR DESCRIPTION
Part of our official full-time work on PDAP has been making sure we're on the same page about terminology—one thing we are going to change is `dataset` → `data source`. I can't rename the DoltHub repo, so I cloned it and made a new one: https://www.dolthub.com/repositories/pdap/data_sources 

This means a bunch of the stuff in pdap_dolt.py broke. We aren't going to be using dolt as our primary db for the foreseeable future, so it's probably going to be deprecated at some point soon anyway.

FWIW, I don't think we need to worry about all the `data_intake` and ETL stuff in here...this was my attempt at a find and replace to fix most of the issues. 