### PR TITLE
Update README.md to reflect new dolthub "About / Data Sources" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To write a scraper, start with [CONTRIBUTING.md](https://github.com/Police-Data-
 For everything else, start with [docs.pdap.io](https://docs.pdap.io/).
 
 ## What data are we scraping?
-The [data sources listed here](https://www.dolthub.com/repositories/pdap/datasets/query/master?q=SELECT+*%0AFROM+%60datasets%60%0Awhere+status_id+%3D+1%0A%0A&active=Tables) are our to-do list. If we should targeting a new data type, suggest it in Discord or make a DoltHub PR!
+The [data sources listed here](https://www.dolthub.com/repositories/pdap/data_sources) are our to-do list. If we should targeting a new data type, suggest it in Discord or make a DoltHub PR!
 
 ## Resources
 Potentially useful tools. If you find something useful, or if one of these is out of date, make a PR!


### PR DESCRIPTION
Previous README had a link provided in "What data are we scraping?" subsection that pointed to a dead-end on do1thub (https://www.dolthub.com/repositories/pdap/datasets/query/master?q=SELECT+*%0AFROM+%60datasets%60%0Awhere+status_id+%3D+1%0A%0A&active=Tables). 

Not sure if the new link I added was exactly where we want this link to point to, currently modified it to point it at the dolthub base data_sources page.