### PR TITLE
Fix scraper crash

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -5,4 +5,3 @@ from .base_scrapers.list_pdf_scrapers import list_pdf_v2
 from .base_scrapers.list_pdf_scrapers import single_pdf_scraper
 from .base_scrapers.opendata import opendata_scraper
 from .base_scrapers.opendata import opendata_scraper2
-from .etl.main import schema_load


### PR DESCRIPTION
As a consequence of commit 7c0975e an unresolved import pointing to one of the deleted files is causing a crash when running many of the older scrapers that use the common scripts:
```Traceback (most recent call last):
  File "/home/kylie/Programming/PDAP-Scrapers/USA/MN/hennepin_county/municipal/minneapolis/archive_opendata.py", line 8, in <module>
    from common import opendata_scraper2
  File "/home/kylie/Programming/PDAP-Scrapers/common/__init__.py", line 8, in <module>
    from .etl.main import schema_load
ModuleNotFoundError: No module named 'common.etl.main'
```
Also I wanted to ask if we're planning on removing the `etl.py` files and their references that are sprinkled throughout the scrapers. If so, I can probably clean these up as well.